### PR TITLE
重構 API 並修正違規記點統計

### DIFF
--- a/src/app/api/announcements/route.js
+++ b/src/app/api/announcements/route.js
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabase/server';
+import { verifyUserAuth, checkRateLimit, handleApiError, logSuccessAction } from '@/lib/apiMiddleware';
+
+// 取得公告列表
+export async function GET(request) {
+  try {
+    // Rate limit 檢查
+    const rateCheck = checkRateLimit(request, 'announcements-get', 30, 60000);
+    if (!rateCheck.success) return rateCheck.error;
+
+    const { searchParams } = new URL(request.url);
+    const isAdmin = searchParams.get('admin') === 'true';
+
+    // 如果為後台請求則需驗證管理員身份
+    if (isAdmin) {
+      const auth = await verifyUserAuth(request, {
+        requireAuth: true,
+        requireAdmin: true,
+        endpoint: '/api/announcements'
+      });
+      if (!auth.success) return auth.error;
+    }
+
+    const supabase = supabaseServer;
+    let query = supabase
+      .from('announcements')
+      .select('id, title, external_urls, created_at, is_active, updated_at, category, application_deadline, announcement_end_date, attachments(id, file_name, stored_file_path)')
+      .order('created_at', { ascending: false });
+
+    if (!isAdmin) {
+      query = query.eq('is_active', true);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    if (isAdmin) {
+      logSuccessAction('GET_ADMIN_ANNOUNCEMENTS', '/api/announcements', {
+        count: data?.length || 0
+      });
+    }
+
+    return NextResponse.json({ success: true, announcements: data || [] });
+  } catch (error) {
+    return handleApiError(error, '/api/announcements');
+  }
+}

--- a/src/app/api/broadcast-line-announcement/route.js
+++ b/src/app/api/broadcast-line-announcement/route.js
@@ -60,7 +60,7 @@ export async function POST(request) {
         // Fetch announcement from Supabase
         const { data: announcement, error: annError } = await supabaseServer
             .from('announcements')
-            .select('title, category, application_start_date, application_end_date, submission_method, target_audience')
+            .select('title, category, application_deadline, announcement_end_date, submission_method, target_audience')
             .eq('id', announcementId)
             .single();
             
@@ -70,9 +70,8 @@ export async function POST(request) {
         }
 
         // **MODIFIED**: Build the plain text message exactly like in the preview component.
-        const startDate = announcement.application_start_date ? new Date(announcement.application_start_date).toLocaleDateString('en-CA') : null;
-        const endDate = announcement.application_end_date ? new Date(announcement.application_end_date).toLocaleDateString('en-CA') : '無期限';
-        const dateString = startDate ? `${startDate} ~ ${endDate}` : endDate;
+        const endDate = announcement.application_deadline ? new Date(announcement.application_deadline).toLocaleDateString('en-CA') : '無期限';
+        const dateString = endDate;
         
         const titleLine = `🎓【分類 ${announcement.category || '未分類'}】 ${announcement.title || '無標題'}`;
         const periodLine = `\n\n⚠️ 申請期間：\n${dateString}`;

--- a/src/app/api/chat/route.js
+++ b/src/app/api/chat/route.js
@@ -143,7 +143,7 @@ export async function POST(request) {
 
         const { data: allAnnouncements, error: announcementsError } = await supabase
             .from('announcements')
-            .select('id, title, summary, target_audience, application_start_date, application_end_date, submission_method, application_limitations')
+            .select('id, title, summary, target_audience, application_deadline, announcement_end_date, submission_method, application_limitations')
             .eq('is_active', true);
 
         if (announcementsError) {
@@ -185,8 +185,8 @@ export async function POST(request) {
 ### 公告標題：《${doc.title}》
 - **摘要:** ${doc.summary.replace(/<[^>]+>/g, ' ')}
 - **適用對象:** ${doc.target_audience.replace(/<[^>]+>/g, ' ')}
-- **申請開始日期:** ${doc.application_start_date || '未指定'}
-- **公告結束日期 (申請截止):** ${doc.application_end_date || '未指定'}
+- **申請截止日期:** ${doc.application_deadline || '未指定'}
+- **公告結束日期:** ${doc.announcement_end_date || '未指定'}
 - **送件方式:** ${doc.submission_method || '未指定'}
 - **申請限制:** ${doc.application_limitations || '未指定'}
 ---`;

--- a/src/app/api/demerits/route.js
+++ b/src/app/api/demerits/route.js
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabase/server';
+import { verifyUserAuth, checkRateLimit, handleApiError, logSuccessAction, validateRequestData } from '@/lib/apiMiddleware';
+
+// 取得目前使用者的違規記點紀錄
+export async function GET(request) {
+  try {
+    // Rate limit 檢查
+    const rateCheck = checkRateLimit(request, 'demerits-get', 20, 60000);
+    if (!rateCheck.success) return rateCheck.error;
+
+    // 驗證使用者身份
+    const auth = await verifyUserAuth(request, {
+      requireAuth: true,
+      endpoint: '/api/demerits'
+    });
+    if (!auth.success) return auth.error;
+
+    const supabase = supabaseServer;
+    const { data, error } = await supabase
+      .from('demerit')
+      .select('id, recorder, reason, created_at')
+      .eq('user_id', auth.user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+
+    logSuccessAction('GET_DEMERITS', '/api/demerits', {
+      userId: auth.user.id,
+      count: data?.length || 0
+    });
+
+    return NextResponse.json({ success: true, records: data || [] });
+  } catch (error) {
+    return handleApiError(error, '/api/demerits');
+  }
+}
+
+// 管理員新增違規記點
+export async function POST(request) {
+  try {
+    // Rate limit 檢查
+    const rateCheck = checkRateLimit(request, 'demerits-post', 10, 60000);
+    if (!rateCheck.success) return rateCheck.error;
+
+    // 驗證管理員身份
+    const auth = await verifyUserAuth(request, {
+      requireAuth: true,
+      requireAdmin: true,
+      endpoint: '/api/demerits'
+    });
+    if (!auth.success) return auth.error;
+
+    // 驗證請求資料
+    const body = await request.json();
+    const validation = validateRequestData(body, ['userId', 'reason']);
+    if (!validation.success) return validation.error;
+
+    const { userId, reason } = validation.data;
+
+    const supabase = supabaseServer;
+
+    // 新增違規記點紀錄
+    const { error: insertError } = await supabase
+      .from('demerit')
+      .insert({
+        user_id: userId,
+        recorder: auth.profile.username,
+        reason: reason
+      });
+    if (insertError) throw insertError;
+
+    // 重新計算使用者的累計記點
+    const { count, error: countError } = await supabase
+      .from('demerit')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId);
+    if (countError) throw countError;
+
+    logSuccessAction('ADD_DEMERIT', '/api/demerits', {
+      adminId: auth.user.id,
+      targetUserId: userId
+    });
+
+    return NextResponse.json({ success: true, total: count ?? 0 });
+  } catch (error) {
+    return handleApiError(error, '/api/demerits');
+  }
+}

--- a/src/app/api/users/[userId]/route.js
+++ b/src/app/api/users/[userId]/route.js
@@ -91,12 +91,22 @@ export async function PUT(request, { params }) {
     }
 
     // 8. 格式化回傳資料
+    // 取得使用者違規記點數量
+    const { count, error: demeritError } = await supabase
+      .from('demerit')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId);
+    if (demeritError) {
+      console.error('Error fetching demerit count:', demeritError);
+    }
+
     const formattedUser = {
       id: data.id,
       studentId: data.student_id || '',
       name: data.username || '',
       email: email,
       role: data.role,
+      demerit: count || 0,
       createdAt: data.created_at,
       avatarUrl: data.avatar_url
     };

--- a/src/app/api/users/route.js
+++ b/src/app/api/users/route.js
@@ -26,11 +26,11 @@ export async function GET(request) {
     const { data: profiles, error } = await supabase
       .from('profiles')
       .select(`
-        id, 
-        student_id, 
-        username, 
-        role, 
-        created_at, 
+        id,
+        student_id,
+        username,
+        role,
+        created_at,
         avatar_url
       `)
       .order('created_at', { ascending: false });
@@ -42,8 +42,25 @@ export async function GET(request) {
 
     // 獲取對應的電子信箱資料
     const userIds = profiles.map(p => p.id);
+
+    // 取得違規記點數量
+    const { data: demerits, error: demeritError } = await supabase
+      .from('demerit')
+      .select('user_id, count:id', { head: false })
+      .in('user_id', userIds)
+      .group('user_id');
+    if (demeritError) {
+      console.error('Error fetching demerits:', demeritError);
+    }
+    const demeritMap = {};
+    if (Array.isArray(demerits)) {
+      demerits.forEach(item => {
+        demeritMap[item.user_id] = item.count;
+      });
+    }
+
     const { data: authUsers, error: emailFetchError } = await supabase.auth.admin.listUsers();
-    
+
     if (emailFetchError) {
       console.error('Error fetching auth users:', emailFetchError);
     }
@@ -59,7 +76,7 @@ export async function GET(request) {
     // 5. 格式化資料並進行脫敏處理
     const formattedUsers = profiles.map(profile => {
       const email = emailMap[profile.id] || '';
-      
+
       return {
         id: profile.id,
         studentId: profile.student_id || '',
@@ -68,6 +85,7 @@ export async function GET(request) {
         email: email ? `${email.substring(0, 3)}***@${email.split('@')[1]}` : '',
         emailFull: email, // 保留完整電子信箱供編輯使用
         role: profile.role || 'user',
+        demerit: demeritMap[profile.id] || 0,
         joinedAt: profile.created_at,
         avatarUrl: profile.avatar_url
       };

--- a/src/components/AnnouncementDetailModal.jsx
+++ b/src/components/AnnouncementDetailModal.jsx
@@ -55,21 +55,17 @@ export default function AnnouncementDetailModal({ isOpen, onClose, announcement 
         if (!announcement) return { displayString: '未指定', isOpen: false };
 
         const now = new Date();
-        const startDate = announcement.application_start_date ? new Date(announcement.application_start_date) : null;
-        const endDate = announcement.application_end_date ? new Date(announcement.application_end_date) : null;
+        const endDate = announcement.application_deadline ? new Date(announcement.application_deadline) : null;
 
         if (endDate) {
             endDate.setHours(23, 59, 59, 999);
         }
 
-        const isOpen = startDate && endDate ? (now >= startDate && now <= endDate) : false;
+        const isOpen = endDate ? now <= endDate : false;
 
-        const formattedStartDate = startDate ? startDate.toLocaleDateString('en-CA') : null;
-        const formattedEndDate = endDate ? new Date(announcement.application_end_date).toLocaleDateString('en-CA') : '無期限';
+        const formattedEndDate = endDate ? new Date(announcement.application_deadline).toLocaleDateString('en-CA') : '無期限';
 
-        const displayString = formattedStartDate
-            ? `${formattedStartDate} ~ ${formattedEndDate}`
-            : formattedEndDate || '未指定';
+        const displayString = formattedEndDate || '未指定';
 
         return { displayString, isOpen };
     }, [announcement]);

--- a/src/components/AnnouncementList.jsx
+++ b/src/components/AnnouncementList.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase/client";
+// 透過後端 API 取得公告資料
 import { Loader2, Paperclip, Link as LinkIcon } from "lucide-react";
 
 // 解析 external_urls 欄位，支援 JSON 陣列或單一字串
@@ -37,22 +37,24 @@ export default function AnnouncementList() {
     const [announcements, setAnnouncements] = useState([]);
     const [loading, setLoading] = useState(true);
 
-    // 自 Supabase 載入公告
+    // 由後端 API 載入公告資料
     useEffect(() => {
         const fetchData = async () => {
-            const { data, error } = await supabase
-                .from("announcements")
-                .select("id, title, external_urls, create_at, attachments(id, file_name, stored_file_path)")
-                .eq("is_active", true)
-                .order("create_at", { ascending: false });
-
-            if (error) {
-                console.error("載入公告時發生錯誤：", error);
+            try {
+                const res = await fetch('/api/announcements');
+                const result = await res.json();
+                if (res.ok) {
+                    setAnnouncements(Array.isArray(result.announcements) ? result.announcements : []);
+                } else {
+                    console.error('載入公告失敗：', result.error);
+                    setAnnouncements([]);
+                }
+            } catch (err) {
+                console.error('載入公告時發生錯誤：', err);
                 setAnnouncements([]);
-            } else {
-                setAnnouncements(data || []);
+            } finally {
+                setLoading(false);
             }
-            setLoading(false);
         };
         fetchData();
     }, []);
@@ -76,7 +78,7 @@ export default function AnnouncementList() {
                 return (
                     <li key={ann.id} className="bg-white border rounded-lg p-6 shadow-sm">
                         <h3 className="text-lg font-semibold text-gray-800">{ann.title}</h3>
-                        <p className="text-sm text-gray-500 mt-1">發布日期：{new Date(ann.create_at).toLocaleDateString("en-CA")}</p>
+                        <p className="text-sm text-gray-500 mt-1">發布日期：{new Date(ann.created_at).toLocaleDateString("en-CA")}</p>
 
                         {links.length > 0 && (
                             <div className="mt-4 space-y-1">

--- a/src/components/CreateAnnouncementModal.jsx
+++ b/src/components/CreateAnnouncementModal.jsx
@@ -203,8 +203,8 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
     const modelRef = useRef(null);
 
     const initialFormData = {
-        title: '', summary: '', category: '', application_start_date: '',
-        application_end_date: '', target_audience: '', application_limitations: '',
+        title: '', summary: '', category: '',
+        application_deadline: '', announcement_end_date: '', target_audience: '', application_limitations: '',
         submission_method: '', external_urls: [{ url: '' }],
         is_active: true,
     };
@@ -367,8 +367,8 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
 - **欄位列表**：
     1.  \`title\` (string | null): 公告的**簡短**標題，必須包含**提供單位**和**獎學金名稱**。例如：「國際崇她社『崇她獎』獎學金」。
     2.  \`category\` (string | null): 根據下方的「代碼定義」從 'A'~'E' 中選擇一個。
-    3.  \`application_start_date\` (string | null): **申請開始日期**。
-    4.  \`application_end_date\` (string | null): **申請結止日期**，格式必須是 'YYYY-MM-DD' 。若只提及月份，以該月最後一天為準。若為區間，以**結束日期**為準，備註: 民國年 + 1911 即為西元年。
+    3.  \`application_deadline\` (string | null): **申請截止日期**，格式必須是 'YYYY-MM-DD' 。若只提及月份，以該月最後一天為準。若為區間，以**結束日期**為準，備註: 民國年 + 1911 即為西元年。
+    4.  \`announcement_end_date\` (string | null): **公告結束日期**，格式必須是 'YYYY-MM-DD' 。若為區間，以**結束日期**為準。
     5.  \`target_audience\` (string | null): **目標對象**。**此欄位必須是 HTML 格式**，並遵循下方的「視覺化與樣式指導」為關鍵字上色。
     6.  \`application_limitations\` (string | null): **兼領限制**。若明確提及**不行**兼領，回傳 'N'，否則一律回傳 'Y'。
     7.  \`submission_method\` (string | null): **送件方式**。簡要說明最終的送件管道。
@@ -405,8 +405,8 @@ export default function CreateAnnouncementModal({ isOpen, onClose, refreshAnnoun
 {
   "title": "國際蘭馨交流協會『讓夢想起飛』獎學金",
   "category": "C",
-  "application_start_date": null,
-  "application_end_date": "2025-07-23",
+  "application_deadline": "2025-07-23",
+  "announcement_end_date": null,
   "target_audience": "<ul><li>國內各大學日間部、進修學士班之<span style=\\"color: #F79420; font-weight: bold;\\">在學女學生</span>。</li><li>歷年學業平均成績達 <span style=\\"color: #F79420; font-weight: bold;\\">70分</span>。</li></ul>",
   "application_limitations": "N",
   "submission_method": "送件至生輔組或將申請資料寄送至承辦人員信箱: act5718@gmail.com",
@@ -525,8 +525,8 @@ ${selectedFiles.length > 0 ? `\n# 檔案資料來源` : ''}
                 title: formData.title,
                 summary: formData.summary,
                 category: formData.category,
-                application_start_date: formData.application_start_date || null,
-                application_end_date: formData.application_end_date || null,
+                application_deadline: formData.application_deadline || null,
+                announcement_end_date: formData.announcement_end_date || null,
                 target_audience: formData.target_audience,
                 application_limitations: formData.application_limitations,
                 submission_method: formData.submission_method,
@@ -607,8 +607,8 @@ ${selectedFiles.length > 0 ? `\n# 檔案資料來源` : ''}
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                         <div><label htmlFor="is_active" className="block text-sm font-semibold text-gray-700 mb-1.5">公告狀態</label><select id="is_active" name="is_active" className={inputStyles} value={formData.is_active} onChange={e => setFormData(prev => ({ ...prev, is_active: e.target.value === 'true' }))}><option value={true}>上架</option><option value={false}>下架</option></select></div>
                         <div><label htmlFor="category" className="block text-sm font-semibold text-gray-700 mb-1.5">獎學金分類</label><select id="category" name="category" className={inputStyles} value={formData.category} onChange={handleChange}><option value="">請選擇</option><option value="A">A：各縣市政府獎學金</option><option value="B">B：縣市政府以外之各級公家機關及公營單位獎學金</option><option value="C">C：宗教及民間各項指定身分獎學金</option><option value="D">D：非公家機關或其他無法歸類的獎助學金</option><option value="E">E：校外獎助學金得獎公告</option><option value="F">F：校內獎助學金</option></select></div>
-                        <div><label htmlFor="application_start_date" className="block text-sm font-semibold text-gray-700 mb-1.5">申請開始日期</label><input type="date" id="application_start_date" name="application_start_date" className={inputStyles} value={formData.application_start_date} onChange={handleChange} /></div>
-                        <div><label htmlFor="application_end_date" className="block text-sm font-semibold text-gray-700 mb-1.5">公告結束日期</label><input type="date" id="application_end_date" name="application_end_date" className={inputStyles} value={formData.application_end_date} onChange={handleChange} /></div>
+                        <div><label htmlFor="application_deadline" className="block text-sm font-semibold text-gray-700 mb-1.5">申請截止日期</label><input type="date" id="application_deadline" name="application_deadline" className={inputStyles} value={formData.application_deadline} onChange={handleChange} /></div>
+                        <div><label htmlFor="announcement_end_date" className="block text-sm font-semibold text-gray-700 mb-1.5">公告結束日期</label><input type="date" id="announcement_end_date" name="announcement_end_date" className={inputStyles} value={formData.announcement_end_date} onChange={handleChange} /></div>
                         <div><label htmlFor="submission_method" className="block text-sm font-semibold text-gray-700 mb-1.5">送件方式</label><input type="text" id="submission_method" name="submission_method" className={inputStyles} value={formData.submission_method} onChange={handleChange} /></div>
                         <div>
                             <label htmlFor="application_limitations" className="block text-sm font-semibold text-gray-700 mb-1.5">兼領限制</label>

--- a/src/components/UpdateAnnouncementModal.jsx
+++ b/src/components/UpdateAnnouncementModal.jsx
@@ -132,7 +132,7 @@ export default function UpdateAnnouncementModal({ isOpen, onClose, announcement,
 
     const [formData, setFormData] = useState({
         title: '', summary: '', is_active: false, category: '',
-        application_start_date: '', application_end_date: '',
+        application_deadline: '', announcement_end_date: '',
         target_audience: '', application_limitations: '',
         submission_method: '', external_urls: [{ url: '' }]
     });
@@ -157,8 +157,8 @@ export default function UpdateAnnouncementModal({ isOpen, onClose, announcement,
                 summary: announcement.summary || '',
                 is_active: announcement.is_active,
                 category: announcement.category || '',
-                application_start_date: announcement.application_start_date || '',
-                application_end_date: announcement.application_end_date || '',
+                application_deadline: announcement.application_deadline || '',
+                announcement_end_date: announcement.announcement_end_date || '',
                 target_audience: announcement.target_audience || '',
                 application_limitations: announcement.application_limitations || '',
                 submission_method: announcement.submission_method || '',
@@ -219,8 +219,8 @@ export default function UpdateAnnouncementModal({ isOpen, onClose, announcement,
                 summary: formData.summary,
                 is_active: formData.is_active,
                 category: formData.category,
-                application_start_date: formData.application_start_date || null,
-                application_end_date: formData.application_end_date || null,
+                application_deadline: formData.application_deadline || null,
+                announcement_end_date: formData.announcement_end_date || null,
                 target_audience: formData.target_audience,
                 application_limitations: formData.application_limitations,
                 submission_method: formData.submission_method,
@@ -309,8 +309,8 @@ export default function UpdateAnnouncementModal({ isOpen, onClose, announcement,
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <div><label htmlFor="is_active" className="block text-sm font-semibold text-gray-700 mb-1.5">公告狀態</label><select id="is_active" name="is_active" className={inputStyles} value={formData.is_active} onChange={e => setFormData(prev => ({ ...prev, is_active: e.target.value === 'true' }))}><option value={false}>下架</option><option value={true}>上架</option></select></div>
                                         <div><label htmlFor="category" className="block text-sm font-semibold text-gray-700 mb-1.5">獎學金分類</label><select id="category" name="category" className={inputStyles} value={formData.category} onChange={handleChange}><option value="">請選擇</option><option value="A">A：各縣市政府獎學金</option><option value="B">B：縣市政府以外之各級公家機關及公營單位獎學金</option><option value="C">C：宗教及民間各項指定身分獎學金</option><option value="D">D：非公家機關或其他無法歸類的獎學金</option><option value="E">E：校外獎助學金得獎公告</option><option value="F">F：校內獎助學金</option></select></div>
-                                        <div><label htmlFor="application_start_date" className="block text-sm font-semibold text-gray-700 mb-1.5">申請開始日期</label><input type="date" id="application_start_date" name="application_start_date" className={inputStyles} value={formData.application_start_date} onChange={handleChange} /></div>
-                                        <div><label htmlFor="application_end_date" className="block text-sm font-semibold text-gray-700 mb-1.5">申請截止日期</label><input type="date" id="application_end_date" name="application_end_date" className={inputStyles} value={formData.application_end_date} onChange={handleChange} /></div>
+                                        <div><label htmlFor="application_deadline" className="block text-sm font-semibold text-gray-700 mb-1.5">申請截止日期</label><input type="date" id="application_deadline" name="application_deadline" className={inputStyles} value={formData.application_deadline} onChange={handleChange} /></div>
+                                        <div><label htmlFor="announcement_end_date" className="block text-sm font-semibold text-gray-700 mb-1.5">公告結束日期</label><input type="date" id="announcement_end_date" name="announcement_end_date" className={inputStyles} value={formData.announcement_end_date} onChange={handleChange} /></div>
                                         <div><label htmlFor="submission_method" className="block text-sm font-semibold text-gray-700 mb-1.5">送件方式</label><input type="text" id="submission_method" name="submission_method" className={inputStyles} value={formData.submission_method} onChange={handleChange} /></div>
 
                                         <div>

--- a/src/components/admin/AddDemeritModal.jsx
+++ b/src/components/admin/AddDemeritModal.jsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Ban, Loader2 } from 'lucide-react';
+
+// 管理員新增違規記點的對話框
+export default function AddDemeritModal({ isOpen, onClose, user, onConfirm, isSubmitting }) {
+    const [reason, setReason] = useState('');
+
+    useEffect(() => {
+        if (isOpen) {
+            setReason('');
+        }
+    }, [isOpen]);
+
+    const handleConfirm = () => {
+        onConfirm({ reason });
+    };
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex justify-center items-center p-4"
+                >
+                    <motion.div
+                        initial={{ scale: 0.95, y: -20, opacity: 0 }}
+                        animate={{ scale: 1, y: 0, opacity: 1 }}
+                        exit={{ scale: 0.95, y: 20, opacity: 0 }}
+                        transition={{ duration: 0.3, ease: 'easeInOut' }}
+                        className="bg-white rounded-xl shadow-xl w-full max-w-md overflow-hidden"
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <div className="p-4 border-b flex justify-between items-center">
+                            <h2 className="text-lg font-bold">為 {user?.name} 記錄違規</h2>
+                            <button onClick={onClose} className="text-gray-500 hover:text-gray-700 p-1 rounded-full">
+                                <X size={20} />
+                            </button>
+                        </div>
+                        <div className="p-4 space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">事由</label>
+                                <textarea
+                                    value={reason}
+                                    onChange={e => setReason(e.target.value)}
+                                    rows={4}
+                                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                    placeholder="請輸入違規事由"
+                                    disabled={isSubmitting}
+                                />
+                            </div>
+                        </div>
+                        <div className="p-4 bg-gray-50 flex justify-end">
+                            <button
+                                onClick={handleConfirm}
+                                disabled={isSubmitting || !reason.trim()}
+                                className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white text-sm font-semibold rounded-lg hover:bg-red-700 disabled:bg-red-400"
+                            >
+                                {isSubmitting ? <Loader2 size={16} className="animate-spin" /> : <Ban size={16} />}
+                                <span>{isSubmitting ? '送出中...' : '記錄違規'}</span>
+                            </button>
+                        </div>
+                    </motion.div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/src/components/admin/AnnouncementPDF.jsx
+++ b/src/components/admin/AnnouncementPDF.jsx
@@ -314,10 +314,11 @@ const AnnouncementPDF = ({ announcement }) => {
                     </View>
                     <View style={[styles.infoColumn, styles.infoColumnDivider]}>
                         <Text style={styles.sectionTitle}>公告日程</Text>
-                        <Text style={styles.infoTextLabel}>申請開始</Text>
-                        <Text style={{ ...styles.infoTextValue, color: colors.primary }}>{formatDate(announcement.application_start_date)}</Text>
-                        <Text style={{ ...styles.infoTextLabel, marginTop: 8 }}>申請截止</Text>
-                        <Text style={{ ...styles.infoTextValue, color: colors.primary }}>{formatDate(announcement.application_end_date)}</Text>
+                        <Text style={styles.infoTextLabel}>申請截止</Text>
+                        <Text style={{ ...styles.infoTextValue, color: colors.primary }}>{formatDate(announcement.application_deadline)}</Text>
+        
+                        <Text style={{ ...styles.infoTextLabel, marginTop: 8 }}>公告結束</Text>
+                        <Text style={{ ...styles.infoTextValue, color: colors.primary }}>{formatDate(announcement.announcement_end_date)}</Text>
                     </View>
                     <View style={[styles.infoColumn, styles.infoColumnDivider]}>
                         <Text style={styles.sectionTitle}>申請辦法</Text>

--- a/src/components/admin/AnnouncementsTab.jsx
+++ b/src/components/admin/AnnouncementsTab.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { supabase } from '@/lib/supabase/client';
 import CreateAnnouncementModal from '@/components/CreateAnnouncementModal';
 import UpdateAnnouncementModal from '@/components/UpdateAnnouncementModal';
 import DeleteAnnouncementModal from '@/components/DeleteAnnouncementModal';
@@ -55,21 +54,31 @@ export default function AnnouncementsTab() {
     const [preview, setPreview] = useState({ open: false, type: '', html: '', text: '', id: null });
 
     const [searchTerm, setSearchTerm] = useState('');
-    const [sort, setSort] = useState({ column: 'application_end_date', direction: 'desc' });
+    const [sort, setSort] = useState({ column: 'application_deadline', direction: 'desc' });
     const [currentPage, setCurrentPage] = useState(1);
     const [rowsPerPage, setRowsPerPage] = useState(10);
 
     const showToast = (message, type = 'success') => setToast({ show: true, message, type });
     const hideToast = () => setToast(prev => ({ ...prev, show: false }));
 
+    // 自後端 API 取得公告列表（需管理員權限）
     const fetchAnnouncements = useCallback(async () => {
         setLoading(true);
         try {
-            const { data, error } = await supabase.from('announcements').select('*').order('created_at', { ascending: false });
-            if (error) throw error;
-            setAllAnnouncements(data || []);
-        } catch (error) { showToast('無法載入公告列表，請稍後再試', 'error'); }
-        finally { setLoading(false); }
+            const res = await authFetch('/api/announcements?admin=true');
+            const result = await res.json();
+            if (res.ok) {
+                setAllAnnouncements(Array.isArray(result.announcements) ? result.announcements : []);
+            } else {
+                showToast(result.error || '無法載入公告列表，請稍後再試', 'error');
+                setAllAnnouncements([]);
+            }
+        } catch (error) {
+            showToast('無法載入公告列表，請稍後再試', 'error');
+            setAllAnnouncements([]);
+        } finally {
+            setLoading(false);
+        }
     }, []);
 
     useEffect(() => { fetchAnnouncements(); }, [fetchAnnouncements]);
@@ -169,8 +178,8 @@ export default function AnnouncementsTab() {
                             <tr>
                                 <th className="p-4 px-6 font-semibold text-gray-500">標題</th>
                                 <th className="p-4 px-6 font-semibold text-gray-500 w-24">分類</th>
-                                <th className="p-4 px-6 font-semibold text-gray-500 cursor-pointer w-36" onClick={() => handleSort('application_end_date')}>
-                                    <div className="flex items-center">申請截止日 {renderSortIcon('application_end_date')}</div>
+                                <th className="p-4 px-6 font-semibold text-gray-500 cursor-pointer w-36" onClick={() => handleSort('application_deadline')}>
+                                    <div className="flex items-center">申請截止日 {renderSortIcon('application_deadline')}</div>
                                 </th>
                                 <th className="p-4 px-6 font-semibold text-gray-500 w-28">狀態</th>
                                 <th className="p-4 px-6 font-semibold text-gray-500 cursor-pointer w-36" onClick={() => handleSort('updated_at')}>
@@ -189,7 +198,7 @@ export default function AnnouncementsTab() {
                                     <tr key={ann.id} className="transform transition-all duration-300 hover:bg-violet-100/50 hover:shadow-xl z-0 hover:z-10 hover:scale-[1.02]">
                                         <td className="p-4 px-6 font-medium text-gray-800 break-words">{ann.title}</td>
                                         <td className="p-4 px-6 text-gray-600">{ann.category}</td>
-                                        <td className="p-4 px-6 text-gray-600 font-medium">{ann.application_end_date ? new Date(ann.application_end_date).toLocaleDateString('en-CA') : '無期限'}</td>
+                                        <td className="p-4 px-6 text-gray-600 font-medium">{ann.application_deadline ? new Date(ann.application_deadline).toLocaleDateString('en-CA') : '無期限'}</td>
                                         <td className="p-4 px-6">
                                             <span className={`px-2.5 py-1 text-xs font-semibold rounded-full ${ann.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>{ann.is_active ? '上架' : '下架'}</span>
                                         </td>
@@ -258,7 +267,7 @@ export default function AnnouncementsTab() {
                                                         <div className="text-gray-700">{ann.category || '-'}</div>
 
                                                         <div className="font-semibold text-gray-500">申請截止</div>
-                                                        <div className="text-gray-700">{ann.application_end_date ? new Date(ann.application_end_date).toLocaleDateString('en-CA') : '無期限'}</div>
+                                                        <div className="text-gray-700">{ann.application_deadline ? new Date(ann.application_deadline).toLocaleDateString('en-CA') : '無期限'}</div>
 
                                                         <div className="font-semibold text-gray-500">最後更新</div>
                                                         <div className="text-gray-700">{new Date(ann.updated_at).toLocaleDateString()}</div>

--- a/src/components/admin/UsageTab.jsx
+++ b/src/components/admin/UsageTab.jsx
@@ -74,7 +74,7 @@ const Card = ({
                     <h3 className="text-lg font-bold text-gray-900">{title}</h3>
                 </div>
 
-                <p className="mt-4 flex-grow text-sm text-gray-500">{children}</p>
+                <div className="mt-4 flex-grow text-sm text-gray-500">{children}</div>
 
                 {type === 'link' && (
                     <div className={`mt-6 flex items-center justify-end text-sm font-semibold ${theme.linkText}`}>

--- a/src/components/ai-assistant/AnnouncementCard.jsx
+++ b/src/components/ai-assistant/AnnouncementCard.jsx
@@ -22,7 +22,7 @@ const AnnouncementCard = ({ id }) => {
 
             const { data, error: fetchError } = await supabase
                 .from('announcements')
-                .select('id, title, summary, application_end_date')
+                .select('id, title, summary, application_deadline')
                 .eq('id', id)
                 .single();
 
@@ -51,8 +51,8 @@ const AnnouncementCard = ({ id }) => {
         );
     }
 
-    const deadline = announcement.application_end_date
-        ? new Date(announcement.application_end_date).toLocaleDateString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' })
+    const deadline = announcement.application_deadline
+        ? new Date(announcement.application_deadline).toLocaleDateString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' })
         : null;
 
     const announcementUrl = `https://scholarship.ncuesa.org.tw/?announcement_id=${announcement.id}`;

--- a/src/components/previews/LinePreview.jsx
+++ b/src/components/previews/LinePreview.jsx
@@ -23,9 +23,8 @@ const LinePreview = ({ announcement }) => {
     }
 
     // --- 準備核心資訊 ---
-    const startDate = announcement.application_start_date ? new Date(announcement.application_start_date).toLocaleDateString('en-CA') : null;
-    const endDate = announcement.application_end_date ? new Date(announcement.application_end_date).toLocaleDateString('en-CA') : '無期限';
-    const dateString = startDate ? `${startDate} ~ ${endDate}` : endDate;
+    const endDate = announcement.application_deadline ? new Date(announcement.application_deadline).toLocaleDateString('en-CA') : '無期限';
+    const dateString = endDate;
     
     const titleLine = `🎓【分類 ${announcement.category || '未分類'}】 ${announcement.title || '無標題'}`;
     const periodLine = `\n\n⚠️ 申請期間：\n${dateString}`;

--- a/src/lib/supabase/server.js
+++ b/src/lib/supabase/server.js
@@ -1,14 +1,17 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL || 'https://scholarship-api.ncuesa.org.tw';
+// 從環境變數讀取 Supabase 設定
+const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
+// 若未設定必要的環境變數則拋出錯誤
 if (!supabaseUrl || !supabaseServiceKey) {
-  throw new Error('Missing Supabase server environment variables. Please check your .env.local file.');
+  throw new Error('缺少 Supabase 伺服器端環境變數，請確認設定');
 }
 
 console.log('[SUPABASE-SERVER] Configured with URL:', supabaseUrl);
 
+// 建立伺服器端用的 Supabase 用戶端（不保存 session）
 export const supabaseServer = createClient(supabaseUrl, supabaseServiceKey, {
   auth: {
     autoRefreshToken: false,


### PR DESCRIPTION
## Summary
- 後端違規記點 API 取消更新 profiles.demerit，改以 demerit 表重新計算總數
- 使用者列表 API 從 demerit 表統計點數並回傳給前端
- 單一使用者更新 API 同步提供違規點數
- 前台違規記點頁面依記錄數顯示累積點數

## Testing
- `npm test` (missing script: test)
- `NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=... NEXT_PUBLIC_SERVICE_ROLE_KEY=... SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab6b28594832395ba093c289ad42c